### PR TITLE
Fire computed observers when the computed changes.

### DIFF
--- a/mobx/lib/src/core/computed.dart
+++ b/mobx/lib/src/core/computed.dart
@@ -146,21 +146,28 @@ class Computed<T> extends Atom implements Derivation, ObservableValue<T> {
 
   bool _isEqual(T x, T y) => x == y;
 
+  // [fireImmediately] never did quite what it sounded like, and the handler has always
+  // fired immediately. So it is deprecated and now non-functional.
   Function observe(void Function(ChangeNotification<T>) handler,
-      {bool fireImmediately}) {
+      {@deprecated bool fireImmediately}) {
     var firstTime = true;
     T prevValue;
 
     return autorun((_) {
       final newValue = value;
-      if (firstTime == true || fireImmediately == true) {
-        _context.untracked(() {
-          handler(ChangeNotification(
-              type: OperationType.update,
-              object: this,
-              oldValue: prevValue,
-              newValue: newValue));
-        });
+
+      void handleChange() {
+        handler(ChangeNotification(
+            type: OperationType.update,
+            object: this,
+            oldValue: prevValue,
+            newValue: newValue));
+      }
+
+      if (firstTime == true) {
+        _context.untracked(handleChange);
+      } else {
+        handleChange();
       }
 
       firstTime = false;

--- a/mobx/test/computed_test.dart
+++ b/mobx/test/computed_test.dart
@@ -79,6 +79,32 @@ void main() {
       final x = Observable(10);
       final y = Observable(20);
 
+      var observationCount = 0;
+
+      final total = Computed(() => x.value + y.value);
+
+      var expectedComputedValue = x.value + y.value;
+
+      final dispose = total.observe((change) {
+        observationCount++;
+        expect(change.newValue, equals(expectedComputedValue));
+      });
+
+      expect(observationCount, equals(1));
+
+      expectedComputedValue += 10;
+      x.value = x.value + 10;
+      expect(observationCount, equals(2));
+
+      dispose();
+      x.value = 100; // should not invoke observe
+      expect(observationCount, equals(2));
+    });
+
+    test('only runs computation while observed', () {
+      final x = Observable(10);
+      final y = Observable(20);
+
       var executionCount = 0;
 
       final total = Computed(() {
@@ -86,15 +112,13 @@ void main() {
         return x.value + y.value;
       });
 
-      final dispose1 = total.observe((change) {
+      final dispose = total.observe((change) {
         expect(change.newValue, equals(30));
         expect(executionCount, equals(1));
       });
 
-      dispose1(); // no more observations
-
-      x.value = 100; // should not invoke observe
-
+      dispose(); // no more observations
+      x.value = 100; // should not invoke computation
       expect(executionCount, equals(1));
     });
 


### PR DESCRIPTION
Make `Computed.observe` actually call the handler when the computed changes.

I could definitely use some help on this one.

From my attempts to understand what's happening here, it looks like `observe` on Computed is basically nonfunctional. The handler is called when the Computed is initialized, because it is the first time. And then after that it will never be called again, unless it was initialized with `fireImmediately: true`. `fireImmediately` has no impact on whether it fires immediately, since it being the first time is enough to accomplish that. But it does determine whether the handler is ever called again. This seems clear from the code, and both automated testing and manual testing agree.

On the other hand it's hard to believe that this could be true, since one would think that would cause immediate bugs for anyone who used a Computed. I'm about to get pretty over my head since I don't really understand how mobx works under the hood, but I *think* that it doesn't come up much because the Observer flutter widget doesn't use `Computed.observe`, but is notified in other ways? And perhaps in various reactive contexts it might wind up being sort of invisible because if you initialize the `Computed` within that context, it will access the underlying observables, and then be notified anyway, even if the `observe` call didn't work? Or perhaps `observe` is just rarely used. I dunno, I would have expected this to be a problem but since I don't see any issues about it it can't be doing that much harm. But I can definitely reproduce it in my own application (though it didn't come up naturally).

Anyway, the questions I have:
- is the if/else at line 165 correct? I'll leave the more specific question inline there.
- is this a breaking change? The deprecation of fireImmediately shouldn't do too much harm I don't think, especially since it was misleading to begin with. But are there people whose code unintentionally relied on observers not firing? Anyway, that's over my pay grade but I wanted to call it out for consideration.